### PR TITLE
AuthenticationException

### DIFF
--- a/src/AdForm/Auth/Authenticator.php
+++ b/src/AdForm/Auth/Authenticator.php
@@ -3,6 +3,7 @@
 namespace Digitouch\AdForm\Auth;
 
 use Digitouch\AdForm\Client\ClientInterface;
+use Digitouch\AdForm\Exception\Response\AuthenticationException;
 
 class Authenticator
 {
@@ -49,9 +50,13 @@ class Authenticator
         ];
 
         $response = $this->client->sendData('POST', 'Security/Login', $options);
-        $json = json_decode($response->getBody()->getContents(), true);
-        
-        $this->ticket = new Ticket($json['Ticket']);
+        $json = json_decode($response->getBody()->getContents());
+
+        if (!isset($json->Ticket)) {
+            throw new AuthenticationException($json);
+        }
+
+        $this->ticket = new Ticket($json->Ticket);
 
     }
 

--- a/src/AdForm/Exception/Response/AuthenticationException.php
+++ b/src/AdForm/Exception/Response/AuthenticationException.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Digitouch\AdForm\Exception\Response;
+
+class AuthenticationException extends \Exception implements AdFormResponseException
+{
+
+    protected $response;
+
+    public function __construct($response)
+    {
+        parent::__construct($response->Message);
+        $this->response = $response;
+
+    }
+
+    /**
+     * @return Response
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
+
+}

--- a/tests/AdForm/Auth/AuthenticatorTest.php
+++ b/tests/AdForm/Auth/AuthenticatorTest.php
@@ -3,6 +3,7 @@
 namespace Digitouch\Tests\AdForm\Auth;
 
 use Digitouch\AdForm\Client\ClientInterface;
+use Digitouch\AdForm\Exception\Response\AuthenticationException;
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
@@ -57,6 +58,27 @@ JSON;
         $auth = $this->auth;
         $auth->expire();
         $this->assertEquals($auth->isExpired(), true);
+    }
+
+
+    public function testInvalidCredentials()
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Incorrect user name or password');
+
+        // Create a mock
+        $responseBody = <<<JSON
+{"ErrorCode":null,"Message":"Incorrect user name or password","Details":null}
+JSON;
+
+        $responseSize = strlen($responseBody);
+        $stubClient = $this->createMock(ClientInterface::class);
+        $response = new Response(200, ['Content-Length' => $responseSize], $responseBody);
+        // Configure the stub.
+        $stubClient->method('sendData')
+             ->willReturn($response);
+
+        new \Digitouch\AdForm\Auth\Authenticator($stubClient, 'invalid-username', 'invalid-pasword');
     }
 }
 


### PR DESCRIPTION
When invalid credentials are given, AdForm API response does not contain "Ticket" key, thus following notice is triggered:

```
Notice: Undefined index: Ticket
```

It happens here: [Authenticator.php:54](https://github.com/gruppodigitouch/adform-php-sdk/blob/v1.0.7.2/src/AdForm/Auth/Authenticator.php#L54)

This PR introduces `AuthenticationException` which is thrown when "Ticket" is missing in the response.