### PR TITLE
Outdated composer.lock

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "0df4bc6ed78926ba871474c2e7b7299f",
-    "content-hash": "5c6ee4b5b556f962a1acca5bea734714",
+    "content-hash": "6fb01c33a276978c05625a6ccef14096",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -1666,6 +1665,8 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "php": "^5.6 || ^7.0 || ^7.1"
+    },
     "platform-dev": []
 }


### PR DESCRIPTION
When running `composer install`, following warning occurs:

```
Warning: The lock file is not up to date with the latest changes in composer.json. You may be getting outdated dependencies. Run update to update them.
```

This is because of `composer.json` update in 13d1a3ea0c2993c0fa28f02c4238282569102fdb which does not contain `composer.lock` update and thus the `content-hash` and other stuff is outdated.

This PR fixes this inconsistency.